### PR TITLE
Fix names and links with .g8 (issue #3)

### DIFF
--- a/conf/repos.yml
+++ b/conf/repos.yml
@@ -63,16 +63,16 @@ repos:
   - repo: akollegger/unfiltered-neo4j-on-heroku 
     desc: Unfiltered, dispatch to Neo4j, host on Heroku
 
-  - repo: jrevault/scalatra-squeryl.g8 
+  - repo: jrevault/scalatra-squeryl
     desc: SBT, Scalatra, Squeryl with usage samples, includes several plugins
 
-  - repo: exu/phalcon.g8.git 
+  - repo: exu/phalcon
     desc: CPhalcon basic template
 
-  - repo: jackywyz/sbtweb-app.g8.git 
+  - repo: jackywyz/sbtweb-app
     desc: sbt web project basic template
 
-  - repo: mads379/lift-blank.g8 
+  - repo: mads379/lift-blank
     desc: Liftweb minimalistic project
 
   - repo: typesafehub/scala-sbt
@@ -102,29 +102,29 @@ repos:
   - repo: gfrison/proto-app 
     desc: archetype of any Java or Groovy standalone application based on Spring (Grails DSL) and Gradle
 
-  - repo: davececere/unfiltered-squeryl-war.g8 
+  - repo: davececere/unfiltered-squeryl-war
     desc: Full persistent REST api of a single resource. SBT, Scala, Unfiltered, Squeryl, .war build artifact
 
-  - repo: marceloemanoel/gradle-plugin-template.g8 
+  - repo: marceloemanoel/gradle-plugin-template
     desc: Gradle plugin template with info for deploy at maven central.
 
-  - repo: dkrieg/scalatra-angularjs-seed.g8 
+  - repo: dkrieg/scalatra-angularjs-seed
     desc: Template for web app with Scalatra, AngularJS, AngularUI-Boostrap, CoffeeScript, Less, Jasmine, Scala 2.10.0, sbt 0.12.2.
 
-  - repo: jugchennai/scalafx.g8 
+  - repo: jugchennai/scalafx
     desc: Creates a scalaFX project with build support of sbt and dependencies.- 
 
-  - repo: orhanbalci/akka-http-microservice.g8
+  - repo: orhanbalci/akka-http-microservice
     desc: Akka-Http rest service skeleton using Slick FRM 
     
-  - repo: lloydmeta/seed-scala.g8
+  - repo: lloydmeta/seed-scala
     desc: Scala skeleton project w/ Scalatest, Scalafmt, Wartremover, Coursier and scalac options configured
     
-  - repo: lloydmeta/slim-play.g8
+  - repo: lloydmeta/slim-play
     desc: A template for a really slim Play app that is almost Sinatra-like.
     
-  - repo: lloydmeta/ctdi-play.g8
+  - repo: lloydmeta/ctdi-play
     desc: Compile-time DI Play template. Includes test harnesses that work w/ Scalatest
     
-  - repo: silvaren/akka-http.g8
+  - repo: silvaren/akka-http
     desc: Akka HTTP microservice with easy start/stop controls and other features

--- a/conf/repos.yml
+++ b/conf/repos.yml
@@ -126,6 +126,5 @@ repos:
   - repo: lloydmeta/ctdi-play.g8
     desc: Compile-time DI Play template. Includes test harnesses that work w/ Scalatest
     
-    
-    
-    
+  - repo: silvaren/akka-http.g8
+    desc: Akka HTTP microservice with easy start/stop controls and other features

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -43,7 +43,7 @@ layout: false
 
           <div class="span8 offset2">
             <div class="tile">
-              <h2><a href="http://github.com/<%=repo["repo"]%>.g8" style="text-decoration:none;"><%=repo["repo"]%></a></h2>
+              <h2><a href="http://github.com/<%=repo["repo"]%>.g8" style="text-decoration:none;"><%=repo["repo"]%>.g8</a></h2>
               <h4><%=repo["desc"]%></h4>
             </div>
           </div>


### PR DESCRIPTION
Hi guys, this is meant to fix #3 by adding a `.g8` to both names and links so that:

1. People can copy/paste the names to a command such as `sbt new <name>` and have it work;
2. People can click the links and go to their respective Github repo.

In order for this to work I cleaned up all repo names by removing their .g8 suffixes.

